### PR TITLE
Fix looping over multiple configs and overlays

### DIFF
--- a/mender-convert-extract
+++ b/mender-convert-extract
@@ -23,11 +23,11 @@ disk_image=""
 while (( "$#" )); do
   case "$1" in
     -o | --overlay)
-      overlays+="${2}"
+      overlays+=" ${2}"
       shift 2
       ;;
     -c | --config)
-      configs+="${2}"
+      configs+=" ${2}"
       shift 2
       ;;
     -d | --disk-image)

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -42,11 +42,11 @@ source modules/probe.sh
 while (( "$#" )); do
   case "$1" in
     -o | --overlay)
-      overlays+="${2}"
+      overlays+=" ${2}"
       shift 2
       ;;
     -c | --config)
-      configs+="${2}"
+      configs+=" ${2}"
       shift 2
       ;;
     -d | --disk-image)

--- a/mender-convert-package
+++ b/mender-convert-package
@@ -41,11 +41,11 @@ source modules/disk.sh
 while (( "$#" )); do
   case "$1" in
     -o | --overlay)
-      overlays+="${2}"
+      overlays+=" ${2}"
       shift 2
       ;;
     -c | --config)
-      configs+="${2}"
+      configs+=" ${2}"
       shift 2
       ;;
     -d | --disk-image)

--- a/modules/config.sh
+++ b/modules/config.sh
@@ -14,7 +14,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-for config in configs/mender_convert_config "$@"; do
+configs=configs/mender_convert_config
+configs+=" $*"
+
+for config in $configs; do
   log_info "Using configuration file: ${config}"
   source ${config}
 done


### PR DESCRIPTION
In the unfixed version, specifying multiple `--config`s will not work correctly: all config file names would be concatenated to a big string, without spaces in it.